### PR TITLE
chore: point project files at canonical (active) issue numbers

### DIFF
--- a/projects/abrechnung.md
+++ b/projects/abrechnung.md
@@ -7,7 +7,7 @@ categories: [Development]
 status: "Active"
 exodus_score: 1
 last_scanned: "2026-04-06T22:13:24Z"
-issues: [5096]
+issues: [4876]
 updated: "2026-03-26T14:34:29Z"
 ---
 

--- a/projects/asmjit.md
+++ b/projects/asmjit.md
@@ -5,7 +5,7 @@ repo: "https://github.com/asmjit/asmjit"
 platform: github
 categories: [Development]
 status: Active
-issues: [5278]
+issues: [118]
 updated: "2026-03-26T08:20:00Z"
 verified: true
 verified_note: repo alive, room not checked

--- a/projects/athenapk.md
+++ b/projects/athenapk.md
@@ -7,7 +7,7 @@ categories: [Development]
 status: "Active"
 exodus_score: 1
 last_scanned: "2026-04-06T22:13:24Z"
-issues: [5298]
+issues: [4985]
 updated: "2026-04-01T08:27:40Z"
 ---
 

--- a/projects/awesome-android-aosp.md
+++ b/projects/awesome-android-aosp.md
@@ -4,7 +4,7 @@ description: A collection of Android AOSP and ROM development related resources
 repo: "https://github.com/Akipe/awesome-android-aosp"
 platform: github
 status: Active
-issues: [692]
+issues: [125]
 updated: "2024-02-12T17:59:30Z"
 verified: true
 verified_note: repo alive, room not checked

--- a/projects/awesome-electrical-grid-mapping.md
+++ b/projects/awesome-electrical-grid-mapping.md
@@ -7,7 +7,7 @@ categories: [Development]
 status: "Active"
 exodus_score: 2
 last_scanned: "2026-04-06T22:14:33Z"
-issues: [5322]
+issues: [4997]
 updated: "2026-03-31T09:33:19Z"
 ---
 

--- a/projects/bkcouponcrawler.md
+++ b/projects/bkcouponcrawler.md
@@ -4,7 +4,7 @@ repo: "https://github.com/coffeerhyder/BKCouponCrawler"
 platform: github
 categories: [Development]
 status: Active
-issues: [5457]
+issues: [1137]
 updated: "2026-02-03T22:53:41Z"
 verified: true
 verified_note: repo alive, room not checked

--- a/projects/blend2d.md
+++ b/projects/blend2d.md
@@ -5,7 +5,7 @@ repo: "https://github.com/blend2d/blend2d"
 platform: github
 categories: [Development]
 status: Active
-issues: [709]
+issues: [142]
 updated: "2025-11-29T08:14:34Z"
 verified: true
 verified_note: repo alive, room not checked

--- a/projects/blueprint.md
+++ b/projects/blueprint.md
@@ -7,7 +7,7 @@ categories: [Development]
 status: "Active"
 exodus_score: 1
 last_scanned: "2026-04-06T22:13:24Z"
-issues: [5480]
+issues: [5071]
 updated: "2026-02-18T17:54:16Z"
 ---
 

--- a/projects/brouter-web.md
+++ b/projects/brouter-web.md
@@ -7,7 +7,7 @@ categories: [Development]
 status: "Active"
 exodus_score: 1
 last_scanned: "2026-04-06T22:13:24Z"
-issues: [5518]
+issues: [5097]
 updated: "2026-04-01T20:05:47Z"
 ---
 

--- a/projects/circuitikz.md
+++ b/projects/circuitikz.md
@@ -5,7 +5,7 @@ repo: "https://github.com/circuitikz/circuitikz"
 platform: github
 categories: [Development]
 status: Active
-issues: [5598]
+issues: [1189]
 updated: "2026-03-08T12:13:49Z"
 verified: true
 verified_note: repo alive, room not checked

--- a/projects/codespan.md
+++ b/projects/codespan.md
@@ -5,7 +5,7 @@ repo: "https://github.com/brendanzab/codespan"
 platform: github
 categories: [Development]
 status: Active
-issues: [732]
+issues: [165]
 updated: "2026-02-28T10:33:10Z"
 verified: true
 verified_note: repo alive, room not checked

--- a/projects/coz.md
+++ b/projects/coz.md
@@ -7,7 +7,7 @@ categories: [Development]
 status: "Active"
 exodus_score: 3
 last_scanned: "2026-04-06T22:14:33Z"
-issues: [5714]
+issues: [3008]
 updated: "2026-02-11T21:33:31Z"
 ---
 

--- a/projects/cts.md
+++ b/projects/cts.md
@@ -7,7 +7,7 @@ categories: [Development]
 status: "Active"
 exodus_score: 1
 last_scanned: "2026-04-06T22:13:24Z"
-issues: [5745]
+issues: [3019]
 updated: "2026-03-31T02:25:29Z"
 ---
 

--- a/projects/distribution.md
+++ b/projects/distribution.md
@@ -5,7 +5,7 @@ repo: "https://github.com/OpenMandrivaAssociation/distribution"
 platform: github
 categories: [Development]
 status: Active
-issues: [5887]
+issues: [5458]
 updated: "2025-07-19T04:33:01Z"
 exodus_score: 1
 last_scanned: "2026-04-10T00:32:33Z"

--- a/projects/dnglab.md
+++ b/projects/dnglab.md
@@ -5,7 +5,7 @@ repo: "https://github.com/dnglab/dnglab"
 platform: github
 categories: [Development]
 status: Active
-issues: [5900]
+issues: [1266]
 updated: "2026-03-27T07:50:28Z"
 verified: true
 verified_note: repo alive, room not checked

--- a/projects/einsteinpy.md
+++ b/projects/einsteinpy.md
@@ -5,7 +5,7 @@ repo: "https://github.com/einsteinpy/einsteinpy"
 platform: github
 categories: [Development]
 status: Active
-issues: [5980]
+issues: [1299]
 updated: "2024-06-25T23:59:35Z"
 verified: true
 verified_note: repo alive, room not checked

--- a/projects/embedded-graphics-framebuf.md
+++ b/projects/embedded-graphics-framebuf.md
@@ -5,7 +5,7 @@ repo: "https://github.com/bernii/embedded-graphics-framebuf"
 platform: github
 categories: [Development]
 status: Active
-issues: [749]
+issues: [185]
 updated: "2024-11-11T17:42:59Z"
 verified: true
 verified_note: repo alive, room not checked

--- a/projects/europa.md
+++ b/projects/europa.md
@@ -7,7 +7,7 @@ categories: [Development]
 status: "Active"
 exodus_score: 1
 last_scanned: "2026-04-06T22:13:24Z"
-issues: [6101]
+issues: [5648]
 updated: "2022-06-18T14:21:05Z"
 ---
 

--- a/projects/farmos.md
+++ b/projects/farmos.md
@@ -5,7 +5,7 @@ repo: "https://github.com/farmOS/farmOS"
 platform: github
 categories: [Development]
 status: Active
-issues: [6141]
+issues: [1400]
 updated: "2026-04-03T11:43:05Z"
 verified: true
 verified_note: repo alive, room not checked

--- a/projects/firenvim.md
+++ b/projects/firenvim.md
@@ -5,7 +5,7 @@ repo: "https://github.com/glacambre/firenvim"
 platform: github
 categories: [Development]
 status: Active
-issues: [6188]
+issues: [3234]
 updated: "2026-03-27T07:00:58Z"
 exodus_score: 1
 last_scanned: "2026-04-10T00:32:33Z"

--- a/projects/flake-utils.md
+++ b/projects/flake-utils.md
@@ -7,7 +7,7 @@ categories: [Development]
 status: "Active"
 exodus_score: 1
 last_scanned: "2026-04-06T22:14:33Z"
-issues: [6202]
+issues: [5736]
 updated: "2024-11-13T21:27:18Z"
 ---
 

--- a/projects/flatcar-linux-update-operator.md
+++ b/projects/flatcar-linux-update-operator.md
@@ -5,7 +5,7 @@ repo: "https://github.com/flatcar/flatcar-linux-update-operator"
 platform: github
 categories: [Development]
 status: Active
-issues: [6218]
+issues: [1425]
 updated: "2026-03-31T14:11:29Z"
 verified: true
 verified_note: repo alive, room not checked

--- a/projects/flatcar-terraform.md
+++ b/projects/flatcar-terraform.md
@@ -5,7 +5,7 @@ repo: "https://github.com/flatcar/flatcar-terraform"
 platform: github
 categories: [Development]
 status: Active
-issues: [6220]
+issues: [1428]
 updated: "2026-03-31T12:36:44Z"
 verified: true
 verified_note: repo alive, room not checked

--- a/projects/flatcar.md
+++ b/projects/flatcar.md
@@ -5,7 +5,7 @@ repo: "https://github.com/flatcar/Flatcar"
 platform: github
 categories: [Development]
 status: Active
-issues: [6222]
+issues: [1431]
 updated: "2026-04-03T07:29:09Z"
 verified: true
 verified_note: repo alive, room not checked

--- a/projects/flora-server.md
+++ b/projects/flora-server.md
@@ -5,7 +5,7 @@ repo: "https://github.com/flora-pm/flora-server"
 platform: github
 categories: [Development]
 status: Active
-issues: [6236]
+issues: [1439]
 updated: "2026-04-03T21:43:26Z"
 verified: true
 verified_note: repo alive, room not checked

--- a/projects/fury-old.md
+++ b/projects/fury-old.md
@@ -5,7 +5,7 @@ repo: "https://github.com/propensive/fury-old"
 platform: github
 categories: [Development]
 status: Active
-issues: [6312]
+issues: [5843]
 updated: "2024-09-03T21:34:24Z"
 exodus_score: 1
 last_scanned: "2026-04-10T00:32:33Z"

--- a/projects/gaphor.md
+++ b/projects/gaphor.md
@@ -7,7 +7,7 @@ categories: [Development]
 status: "Active"
 exodus_score: 3
 last_scanned: "2026-04-06T22:14:33Z"
-issues: [6321]
+issues: [3301]
 updated: "2026-04-06T12:38:24Z"
 ---
 

--- a/projects/generic.md
+++ b/projects/generic.md
@@ -7,7 +7,7 @@ categories: [Development]
 status: "Active"
 exodus_score: 1
 last_scanned: "2026-04-06T22:13:24Z"
-issues: [6337]
+issues: [3306]
 updated: "2026-04-01T22:58:40Z"
 ---
 

--- a/projects/gnome-shell-extension-openweather.md
+++ b/projects/gnome-shell-extension-openweather.md
@@ -7,7 +7,7 @@ categories: [Development]
 status: "Active"
 exodus_score: 1
 last_scanned: "2026-04-06T22:14:33Z"
-issues: [6401]
+issues: [5930]
 updated: "2024-03-27T15:57:57Z"
 ---
 

--- a/projects/go-skype-bridge.md
+++ b/projects/go-skype-bridge.md
@@ -7,7 +7,7 @@ categories: [Development]
 status: "Active"
 exodus_score: 4
 last_scanned: "2026-04-06T22:14:33Z"
-issues: [6423]
+issues: [3334]
 updated: "2023-02-23T13:28:09Z"
 ---
 

--- a/projects/indico.md
+++ b/projects/indico.md
@@ -7,7 +7,7 @@ categories: [Development]
 status: "Active"
 exodus_score: 2
 last_scanned: "2026-04-06T22:14:33Z"
-issues: [6633]
+issues: [3423]
 updated: "2026-04-06T12:34:08Z"
 ---
 

--- a/projects/install-doctor.md
+++ b/projects/install-doctor.md
@@ -7,7 +7,7 @@ categories: [Development]
 status: "Active"
 exodus_score: 0
 last_scanned: "2026-04-06T22:13:24Z"
-issues: [6643]
+issues: [3426]
 updated: "2026-03-17T03:34:06Z"
 ---
 

--- a/projects/ipfs-cluster-website.md
+++ b/projects/ipfs-cluster-website.md
@@ -7,7 +7,7 @@ categories: [Development]
 status: "Active"
 exodus_score: 2
 last_scanned: "2026-04-06T22:13:24Z"
-issues: [6660]
+issues: [3435]
 updated: "2026-01-03T10:45:41Z"
 ---
 

--- a/projects/ipfs-cluster.md
+++ b/projects/ipfs-cluster.md
@@ -7,7 +7,7 @@ categories: [Development]
 status: "Active"
 exodus_score: 2
 last_scanned: "2026-04-06T22:13:24Z"
-issues: [6661]
+issues: [3436]
 updated: "2026-03-23T11:16:22Z"
 ---
 

--- a/projects/ipfs-gui.md
+++ b/projects/ipfs-gui.md
@@ -7,7 +7,7 @@ categories: [Development]
 status: "Active"
 exodus_score: 2
 last_scanned: "2026-04-06T22:13:24Z"
-issues: [6670]
+issues: [3444]
 updated: "2025-05-09T19:49:44Z"
 ---
 

--- a/projects/js-kubo-rpc-client.md
+++ b/projects/js-kubo-rpc-client.md
@@ -7,7 +7,7 @@ categories: [Development]
 status: "Active"
 exodus_score: 1
 last_scanned: "2026-04-06T22:13:24Z"
-issues: [6757]
+issues: [3493]
 updated: "2026-03-01T15:59:39Z"
 ---
 

--- a/projects/jupiter.md
+++ b/projects/jupiter.md
@@ -7,7 +7,7 @@ categories: [Development]
 status: "Active"
 exodus_score: 2
 last_scanned: "2026-04-06T22:14:33Z"
-issues: [6770]
+issues: [6291]
 updated: "2022-05-01T03:42:50Z"
 ---
 

--- a/projects/kannader.md
+++ b/projects/kannader.md
@@ -5,7 +5,7 @@ repo: "https://github.com/Ekleog/kannader"
 platform: github
 categories: [Development]
 status: Active
-issues: [6791]
+issues: [1545]
 updated: "2024-02-11T09:59:52Z"
 verified: true
 verified_note: repo alive, room not checked

--- a/projects/labgrid.md
+++ b/projects/labgrid.md
@@ -7,7 +7,7 @@ categories: [Development]
 status: "Active"
 exodus_score: 4
 last_scanned: "2026-04-06T22:13:24Z"
-issues: [6831]
+issues: [3517]
 updated: "2026-04-01T18:02:10Z"
 ---
 

--- a/projects/lambda.md
+++ b/projects/lambda.md
@@ -7,7 +7,7 @@ categories: [Development]
 status: "Active"
 exodus_score: 2
 last_scanned: "2026-04-06T22:14:33Z"
-issues: [6837]
+issues: [3519]
 updated: "2026-04-06T12:02:39Z"
 ---
 

--- a/projects/ledgersmb.md
+++ b/projects/ledgersmb.md
@@ -7,7 +7,7 @@ categories: [Development]
 status: "Active"
 exodus_score: 1
 last_scanned: "2026-04-06T22:13:24Z"
-issues: [6867]
+issues: [3535]
 updated: "2026-04-06T06:52:13Z"
 ---
 

--- a/projects/librelingo.md
+++ b/projects/librelingo.md
@@ -5,7 +5,7 @@ repo: "https://github.com/kantord/LibreLingo"
 platform: github
 categories: [Development]
 status: Active
-issues: [6900]
+issues: [3548]
 updated: "2025-01-16T10:20:48Z"
 exodus_score: 1
 last_scanned: "2026-04-10T00:32:33Z"

--- a/projects/libsurvive.md
+++ b/projects/libsurvive.md
@@ -5,7 +5,7 @@ repo: "https://github.com/collabora/libsurvive"
 platform: github
 categories: [Development]
 status: Active
-issues: [6916]
+issues: [1565]
 updated: "2026-03-23T20:55:11Z"
 verified: true
 verified_note: repo alive, room not checked


### PR DESCRIPTION
## Summary

Forty-six \`projects/*.md\` files were pointing at duplicate tracking issues left behind by the old \`sync-issues.py\` race condition. Reconciled them against the canonical (lowest-numbered open) issue per title.

Surfaced while bulk-tagging the \`client-links\` cohort (#7237) — the wrong tags were moved to the correct issues out-of-band, and closed dupes carry a back-link comment to the active issue. This commit just lands the project-file side of the fix.

\`scripts/reconcile-issues.py\` only rewrites \`issues: [...]\` when it's empty, so these stale-but-non-empty pointers were never auto-corrected.

## Test plan
- [x] All 46 changes are single-line \`issues: [N] → issues: [M]\` swaps
- [x] No file overlap with the math FP exclusion branch
- [x] Canonical issues already carry the \`client-links\` label and meta-link comment